### PR TITLE
Fixed method argument name in Bulk Upsert example

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ Example
 client.bulk.upsert('Contact', [
     {'LastName': 'Lindstrom', 'Email': 'test@example.com', 'MyId__c': 1},
     {'LastName': 'Something else', 'Email': 'test@example.com', 'MyId__c': 2}
-], external_id_field='MyId__c')
+], external_id_field_name='MyId__c')
 ```
 Returns
 ```python


### PR DESCRIPTION
The correct attribute is `external_id_field_name` as opposed to `external_id_field`.